### PR TITLE
Several (experimental) rewriter performance improvements

### DIFF
--- a/libraries/mcrl2/src/aterm/mod.rs
+++ b/libraries/mcrl2/src/aterm/mod.rs
@@ -5,11 +5,20 @@
 //! mechanism on the Rust side, which is used during garbage collection to mark
 //! terms as being reachable.
 //! 
+//! Terms are first-order terms f(t0, ..., tn) where f is a function symbol of arity
+//! n+1 and t0 to tn are terms. They are stored immutably and maximally shared in the
+//! main memory using a hash table. These are periodically garbage collected to remove
+//! unused terms.
+//! 
 //! Instead of `unprotected_aterm` there are [ATermRef] classes whose lifetime
 //! is bound by an existing term, providing a safe abstracting for terms that
 //! are implicitly protected by for example occuring as subterm of another
 //! protected term. They can be upgraded to a protected term using "protect" and
 //! borrowed using "borrow".
+//! 
+//! There are [ATerm] objects that protected a term using the thread local protection
+//! set mechnanism, i.e. they are not [Send], and [ATermGlobal] which are protected
+//! using a global protection scheme. Furthermore, there
 
 pub mod aterm_builder;
 pub mod aterm_container;

--- a/libraries/sabre/src/innermost_rewriter.rs
+++ b/libraries/sabre/src/innermost_rewriter.rs
@@ -2,8 +2,8 @@ use std::{cell::RefCell, rc::Rc};
 
 use log::{debug, info, trace};
 use mcrl2::{
-    aterm::{ATerm, ATermRef, TermPool},
-    data::{DataApplication, DataExpression, DataExpressionRef},
+    aterm::{Protected, TermPool},
+    data::{DataExpression, DataExpressionRef},
 };
 
 use crate::{
@@ -55,6 +55,8 @@ impl InnermostRewriter {
 
         stats.recursions += 1;
 
+        let mut tmp_arguments = Protected::new(Vec::<DataExpressionRef<'static>>::new());
+
         let mut stack = InnermostStack::default();
         let mut write_terms = stack.terms.write();
         let mut write_configs = stack.configs.write();
@@ -105,7 +107,7 @@ impl InnermostRewriter {
 
                         let arguments = &write_terms[length - arity..];
 
-                        let match_term = MatchTerm::new(symbol, arguments);
+                        let match_term = MatchTerm::new(symbol, arguments, &mut tmp_arguments);
 
                         // Remove the arguments from the stack.
                         write_terms.drain(length - arity..);

--- a/libraries/sabre/src/innermost_rewriter.rs
+++ b/libraries/sabre/src/innermost_rewriter.rs
@@ -23,7 +23,7 @@ impl RewriteEngine for InnermostRewriter {
         debug!("input: {}", t);
 
         let result =
-            InnermostRewriter::rewrite_aux(&mut self.tp.borrow_mut(), &self.apma, t, &mut stats);
+            InnermostRewriter::rewrite_aux(&mut self.tp.borrow_mut(), &mut self.stack, &mut stats, &self.apma, t);
         info!(
             "{} rewrites, {} single steps and {} symbol comparisons",
             stats.recursions, stats.rewrite_steps, stats.symbol_comparisons
@@ -38,32 +38,49 @@ impl InnermostRewriter {
 
         info!("ATerm pool: {}", tp.borrow());
         InnermostRewriter {
-            tp: tp.clone(),
             apma,
+            tp: tp.clone(),
+            stack: InnermostStack::default(),
         }
     }
 
-    /// Function to rewrite a term 't'. The elements of the automaton 'states' and 'tp' are passed
-    /// as separate parameters to satisfy the borrow checker.
+    /// Function to rewrite a term 't'. The elements of the automaton 'states'
+    /// and 'tp' are passed as separate parameters to satisfy the borrow
+    /// checker.
+    /// 
+    /// # Details
+    /// 
+    /// Uses a stack of terms and configurations to avoid recursions and to keep
+    /// track of terms in normal forms without explicit tagging. The configuration
+    /// stack consists of three different possible values with the following semantics
+    ///     - Return(): Returns the top of the stack.
+    ///     - Rewrite(index): Updates the configuration to rewrite the top of the term stack
+    ///                       and places the result on the given index.
+    ///     - Construct(arity, index, result):
+    /// 
     pub(crate) fn rewrite_aux(
         tp: &mut TermPool,
+        stack: &mut InnermostStack,
+        stats: &mut RewritingStatistics,
         automaton: &SetAutomaton<AnnouncementInnermost>,
         input_term: DataExpression,
-        stats: &mut RewritingStatistics,
     ) -> DataExpression {
         debug_assert!(!input_term.is_default(), "Cannot rewrite the default term");
 
         stats.recursions += 1;
+        {
+            let mut write_terms = stack.terms.write();
+            let mut write_configs = stack.configs.write();
 
-        let mut tmp_arguments = Protected::new(Vec::<DataExpressionRef<'static>>::new());
+            // Push the result term to the stack.
+            let top_of_stack = write_terms.len();
+            write_configs.push(Config::Return());
+            write_terms.push(DataExpressionRef::default());
+            InnermostStack::add_rewrite(&mut write_configs, &mut write_terms, input_term.copy(), top_of_stack);
+        }
 
-        let mut stack = InnermostStack::default();
-        let mut write_terms = stack.terms.write();
-        let mut write_configs = stack.configs.write();
-        write_terms.push(DataExpressionRef::default());
-        InnermostStack::add_rewrite(&mut write_configs, &mut write_terms, input_term.copy(), 0);
-        drop(write_terms);
-        drop(write_configs);
+        
+        let mut tmp_arguments: Protected<Vec<DataExpressionRef<'static>>> = Protected::new(vec![]);
 
         loop {
             trace!("{}", stack);
@@ -99,6 +116,7 @@ impl InnermostRewriter {
                                 top_of_stack + offset,
                             );
                         }
+                        drop(write_configs);
                     }
                     Config::Construct(symbol, arity, index) => {
                         // Take the last arity arguments.
@@ -112,8 +130,9 @@ impl InnermostRewriter {
                         // Remove the arguments from the stack.
                         write_terms.drain(length - arity..);
                         drop(write_terms);
+                        drop(write_configs);
 
-                        match InnermostRewriter::find_match(tp, automaton, &match_term, stats) {
+                        match InnermostRewriter::find_match(tp, stack, stats, automaton, &match_term) {
                             Some((announcement, annotation)) => {
                                 if log::log_enabled!(log::Level::Debug) {
                                     // Only create this when debug logging is enabled.
@@ -126,7 +145,9 @@ impl InnermostRewriter {
                                     );
                                 }
 
+                                // Reacquire the write access and add the matching RHSStack.
                                 let mut write_terms = stack.terms.write();
+                                let mut write_configs = stack.configs.write();
                                 InnermostStack::integrate(
                                     &mut write_configs,
                                     &mut write_terms,
@@ -144,46 +165,43 @@ impl InnermostRewriter {
                                 write_terms[index] = t.into();
                             }
                         }
+                    },
+                    Config::Return() => {                
+                        let mut write_terms = stack.terms.write();
+                                        
+                        return write_terms
+                            .pop()
+                            .expect("The result should be the last element on the stack")
+                            .protect();
                     }
                 }
 
-                for (index, term) in stack.terms.write().iter().enumerate() {
+                let read_configs = stack.configs.read();
+                for (index, term) in stack.terms.read().iter().enumerate() {
                     if term.is_default() {
                         debug_assert!(
-                            write_configs.iter().any(|x| {
+                            read_configs.iter().any(|x| {
                                 match x {
                                     Config::Construct(_, _, result) => index == *result,
                                     Config::Rewrite(result) => index == *result,
+                                    Config::Return() => true,
                                 }
                             }),
-                            "This default term {index} is not a result of any operation."
+                            "The default term at index {index} is not a result of any operation."
                         );
                     }
                 }
-            } else {
-                break;
             }
         }
-
-        debug_assert!(
-            stack.terms.read().len() == 1,
-            "Expect exactly one term on the result stack"
-        );
-
-        let mut write_terms = stack.terms.write();
-
-        write_terms
-            .pop()
-            .expect("The result should be the last element on the stack")
-            .protect()
     }
 
     /// Use the APMA to find a match for the given term.
     fn find_match<'a>(
         tp: &mut TermPool,
+        stack: &mut InnermostStack,
+        stats: &mut RewritingStatistics,
         automaton: &'a SetAutomaton<AnnouncementInnermost>,
         match_term: &MatchTerm<'_>,
-        stats: &mut RewritingStatistics,
     ) -> Option<(&'a MatchAnnouncement, &'a AnnouncementInnermost)> {
         // Start at the initial state
         let mut state_index = 0;
@@ -201,7 +219,7 @@ impl InnermostRewriter {
             {
                 for (announcement, annotation) in &transition.announcements {
                     if check_equivalence_classes(match_term, &annotation.equivalence_classes)
-                        && InnermostRewriter::check_conditions(tp, automaton, match_term, annotation, stats)
+                        && InnermostRewriter::check_conditions(tp, stack, stats, automaton, annotation, match_term)
                     {
                         // We found a matching pattern
                         return Some((announcement, annotation));
@@ -225,10 +243,11 @@ impl InnermostRewriter {
     /// Checks whether the condition holds for given match announcement.
     fn check_conditions<'a>(
         tp: &mut TermPool,
-        automaton: &SetAutomaton<AnnouncementInnermost>,
-        t: &MatchTerm<'_>,
-        announcement: &AnnouncementInnermost,
+        stack: &mut InnermostStack,
         stats: &mut RewritingStatistics,
+        automaton: &SetAutomaton<AnnouncementInnermost>,
+        announcement: &AnnouncementInnermost,
+        t: &MatchTerm<'_>,
     ) -> bool {
         if !announcement.conditions.is_empty() {
             let t = t.to_term(tp);
@@ -237,12 +256,12 @@ impl InnermostRewriter {
                 let rhs: DataExpression = c.semi_compressed_rhs.evaluate(&t, tp).into();
                 let lhs: DataExpression = c.semi_compressed_lhs.evaluate(&t, tp).into();
 
-                let rhs_normal = InnermostRewriter::rewrite_aux(tp, automaton, rhs, stats);
+                let rhs_normal = InnermostRewriter::rewrite_aux(tp, stack, stats, automaton, rhs);
                 let lhs_normal = if &lhs == tp.true_term() {
                     // TODO: Store the conditions in a better way. REC now uses a list of equalities while mCRL2 specifications have a simple condition.
                     lhs
                 } else {
-                    InnermostRewriter::rewrite_aux(tp, automaton, lhs, stats)
+                    InnermostRewriter::rewrite_aux(tp, stack, stats, automaton, lhs)
                 };
 
                 if lhs_normal != rhs_normal && c.equality || lhs_normal == rhs_normal && !c.equality {
@@ -259,6 +278,7 @@ impl InnermostRewriter {
 pub struct InnermostRewriter {
     tp: Rc<RefCell<TermPool>>,
     apma: SetAutomaton<AnnouncementInnermost>,
+    stack: InnermostStack,
 }
 
 pub(crate) struct AnnouncementInnermost {

--- a/libraries/sabre/src/lib.rs
+++ b/libraries/sabre/src/lib.rs
@@ -4,7 +4,7 @@
 //! 
 //! This crate does not use unsafe code.
 
-#![forbid(unsafe_code)]
+//#![forbid(unsafe_code)]
 
 pub mod innermost_rewriter;
 pub mod set_automaton;

--- a/libraries/sabre/src/sabre_rewriter.rs
+++ b/libraries/sabre/src/sabre_rewriter.rs
@@ -95,46 +95,6 @@ impl SabreRewriter {
                     let read_terms = cs.terms.read();
                     let leaf_term = &read_terms[leaf_index];
 
-                    // A "side stack" is used besides the configuration stack to
-                    // remember a couple of things. There are 4 options.
-
-                    // 1. There is nothing on the side stack for this
-                    //    configuration. This means we have never seen this
-                    //    configuration before. It is a bud that needs to be
-                    //    explored.
-
-                    // In the remaining three cases we have seen the
-                    // configuration before and have pruned back, either because
-                    // of applying a rewrite rule or just because our depth
-                    // first search has hit the bottom and needs to explore a
-                    // new branch.
-
-                    // 2. There is a side branch. That means we had a hyper
-                    //    transition. The configuration has multiple children in
-                    //    the overall tree. We have already explored some of these
-                    //    child configurations and parked the remaining on the side
-                    //    stack. We are going to explore the next child
-                    //    configuration.
-
-                    // 3. There is a delayed rewrite rule. We had found a
-                    //    matching rewrite rule the first time visiting this
-                    //    configuration but did not want to apply it yet. At the
-                    //    moment this is the case for "duplicating" rewrite rules
-                    //    that copy some subterms. We first examine side branches
-                    //    on the side stack, meaning that we have explored all
-                    //    child configurations. Which, in turn, means that the
-                    //    subterms of the term in the current configuration are in
-                    //    normal form. Thus the duplicating rewrite rule only
-                    //    duplicates terms that are in normal form.
-
-                    // 4. There is another type of delayed rewrite rule: one
-                    //    that is non-linear or has a condition. We had found a
-                    //    matching rewrite rule the first time visiting this
-                    //    configuration but our strategy dictates that we only
-                    //    perform the condition check and check on the equivalence
-                    //    of positions when the subterms are in normal form. We
-                    //    perform the checks and apply the rewrite rule if it
-                    //    indeed matches.
                     match ConfigurationStack::pop_side_branch_leaf(
                         &mut cs.side_branch_stack,
                         leaf_index,

--- a/libraries/sabre/src/utilities/innermost_stack.rs
+++ b/libraries/sabre/src/utilities/innermost_stack.rs
@@ -21,7 +21,11 @@ pub struct InnermostStack {
 impl InnermostStack {
 
     /// Updates the InnermostStack to integrate the rhs_stack instructions.
-    pub fn integrate(write_configs: &mut Protector<Vec<Config>>, write_terms: &mut Protector<Vec<DataExpressionRef<'static>>>, rhs_stack: &RHSStack, term: &DataExpression, result_index: usize) {
+    pub fn integrate(write_configs: &mut Protector<Vec<Config>>, 
+        write_terms: &mut Protector<Vec<DataExpressionRef<'static>>>, 
+        rhs_stack: &RHSStack, 
+        term: &DataExpression, 
+        result_index: usize) {
         
         // TODO: This ignores the first element of the stack, but that is kind of difficult to deal with.
         let top_of_stack = write_terms.len();

--- a/libraries/sabre/src/utilities/innermost_stack.rs
+++ b/libraries/sabre/src/utilities/innermost_stack.rs
@@ -65,7 +65,10 @@ impl InnermostStack {
                     }
                 }
                 Config::Rewrite(_) => {
-                    panic!("This case should not happen");
+                    unreachable!("This case should not happen");
+                }
+                Config::Return() => {
+                    unreachable!("This case should not happen");
                 }
             }
             first = false;
@@ -128,6 +131,8 @@ pub enum Config {
     Rewrite(usize),
     /// Constructs function symbol with given arity at the given index.
     Construct(DataFunctionSymbolRef<'static>, usize, usize),
+    /// Yields the given index as returned term.
+    Return(),
 }
 
 impl Markable for Config {
@@ -182,6 +187,7 @@ impl fmt::Display for Config {
             Config::Construct(symbol, arity, result) => {
                 write!(f, "Construct({}, {}, {})", symbol, arity, result)
             }
+            Config::Return() => write!(f, "Return()"),
         }
     }
 }
@@ -279,7 +285,10 @@ impl RHSStack {
                         write_terms[index] = t.into();
                     }
                     Config::Rewrite(_) => {
-                        panic!("This case should not happen");
+                        unreachable!("This case should not happen");
+                    }
+                    Config::Return() => {
+                        unreachable!("This case should not happen");
                     }
                 }
             } else {
@@ -314,6 +323,7 @@ impl Clone for RHSStack {
                     let f = write.protect(&f.copy().into());
                     write.push(Config::Construct(f.into(), *x, *y));
                 }
+                Config::Return() => write.push(Config::Return()),
             }
         }
         drop(write);

--- a/libraries/sabre/src/utilities/match_term.rs
+++ b/libraries/sabre/src/utilities/match_term.rs
@@ -1,0 +1,192 @@
+use mcrl2::{
+    aterm::{ATermRef, ATermTrait, Protected, TermPool},
+    data::{
+        DataApplication, DataExpression, DataExpressionRef, DataFunctionSymbolRef
+    },
+};
+
+use super::{ExplicitPosition, PositionIndexed};
+
+/// A temporary term that can be used for matching purposes to avoid
+/// constructing a potentially useless term.
+pub struct MatchTerm<'a> {
+    symbol: DataFunctionSymbolRef<'a>,
+    arguments: Protected<Vec<DataExpressionRef<'static>>>,
+}
+
+#[derive(Debug)]
+pub enum MatchTermInner<'a> {
+    Match(
+        DataFunctionSymbolRef<'a>,
+        &'a Protected<Vec<DataExpressionRef<'static>>>,
+    ),
+    Term(DataExpressionRef<'a>),
+}
+
+impl<'a> MatchTerm<'a> {
+    /// Create a new MatchTerm from its components
+    pub fn new(symbol: DataFunctionSymbolRef<'a>,
+        input_arguments: &[DataExpressionRef<'static>],
+    ) -> MatchTerm<'a> {
+        let mut arguments = Protected::new(vec![]);
+        {
+            let mut write = arguments.write();
+            for arg in input_arguments {
+                let arg = write.protect(arg);
+                write.push(arg.into());
+            }
+        }
+
+        MatchTerm { symbol, arguments }
+    }
+
+    /// Converts the match term to an actual term.
+    pub fn to_term(&self, tp: &mut TermPool) -> DataExpression {
+        let read = self.arguments.read();
+        if read.is_empty() {
+            self.symbol.protect().into()
+        } else {
+            DataApplication::from_refs(tp, &self.symbol, &read).into()
+        }
+    }
+
+    /// Returns the function symbol of the term without constructing it.
+    pub fn data_function_symbol(&self, position: &ExplicitPosition) -> DataFunctionSymbolRef<'_> {
+        match self.get_position(position) {
+            MatchTermInner::Match(symbol, _) => {
+                unsafe {
+                    std::mem::transmute(symbol.copy())
+                }
+            },
+            MatchTermInner::Term(t) => {
+                unsafe {
+                    std::mem::transmute(DataExpressionRef::from(t.copy()).data_function_symbol())
+                }
+            }
+        }
+    }
+}
+
+impl PositionIndexed for MatchTerm<'_> {
+    type Target<'a> = MatchTermInner<'a> where Self: 'a;
+
+    fn get_position<'a>(&'a self, position: &ExplicitPosition) -> Self::Target<'a> {
+
+        // Loop through the position
+        let mut it = position.indices.iter();
+        match it.next() {
+            None => {
+                MatchTermInner::Match(self.symbol.copy(), &self.arguments)
+            }
+            Some(index) => {
+                let read = self.arguments.read();
+
+                // Take into account that [symbol, t1, ..., tn]
+                let root = if *index == 1 {
+                    let t: ATermRef = self.symbol.copy().into();
+                    let t: DataExpressionRef = t.into();
+                    t
+                } else {
+                    read[*index - 2].copy()
+                };
+
+                let mut result = root.copy();
+
+                for index in it {
+                    result = result.arg(index - 1).upgrade(&root).into(); // Note that positions are 1 indexed.
+                }
+        
+                unsafe { MatchTermInner::Term(std::mem::transmute(result)) }
+            }
+        }
+    }
+}
+
+impl<'a> PartialEq for MatchTermInner<'a> {
+    fn eq(&self, other: &Self) -> bool {
+        match self {
+            MatchTermInner::Match(symbol, arguments) => match other {
+                MatchTermInner::Match(other_symbol, other_arguments) => {
+                    symbol == other_symbol && arguments == other_arguments
+                }
+                MatchTermInner::Term(other_t) => {
+
+                    *symbol == other_t.data_function_symbol()
+                        && arguments
+                            .read()
+                            .iter()
+                            .map(|t| t.copy())
+                            .eq(other_t.data_arguments().map(|t| DataExpressionRef::from(t)))
+                }
+            },
+            MatchTermInner::Term(t) => match other {
+                MatchTermInner::Match(other_symbol, other_arguments) => {
+                    
+                    t.data_function_symbol() == *other_symbol
+                        && t.data_arguments()
+                            .map(|t| DataExpressionRef::from(t))
+                            .eq(other_arguments.read().iter().map(|t| t.copy()))
+                }
+
+                MatchTermInner::Term(other_t) => t == other_t,
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ahash::AHashSet;
+    use mcrl2::{aterm::{random_term, ATermRef}, data::is_data_expression};
+
+    use rand::{rngs::StdRng, Rng, SeedableRng};
+    use test_log::test;
+
+    use crate::utilities::{to_untyped_data_expression, PositionIterator};
+
+    use super::*;
+
+    #[test]
+    fn test_match_term() {
+        let mut tp = TermPool::new();
+        
+        let seed: u64 =  rand::thread_rng().gen();
+        println!("seed: {}", seed);
+        let mut rng = StdRng::seed_from_u64(seed);
+
+        for _ in 0..100 {
+            let t = random_term(&mut tp, 
+                &mut rng, 
+                &[("f".to_string(), 2)],
+                &["a".to_string(), "b".to_string()],
+                10);
+            let t = to_untyped_data_expression(&mut tp, &t, &AHashSet::new());
+
+            let mut args = Protected::new(Vec::<DataExpressionRef<'static>>::new());
+            let mut write = args.write();
+            for arg in t.data_arguments() {
+                let arg = write.protect(&arg);
+                write.push(arg.into());
+            }
+
+            let match_term = MatchTerm::new(t.data_function_symbol(), &write);
+
+            // Check that the match term is equal to the term from which it was constructed
+            println!("Testing {:?}", t);
+            assert_eq!(match_term.get_position(&ExplicitPosition::default()), MatchTermInner::Term(t.copy()));
+            assert_eq!(MatchTermInner::Term(t.copy()), match_term.get_position(&ExplicitPosition::default()));
+
+            let t: &ATermRef = &t;
+            for (subterm, position) in PositionIterator::new(t.copy()) {
+                if is_data_expression(&subterm) {
+                    println!("Position {}", position);
+                    assert_eq!(match_term.get_position(&position), MatchTermInner::Term(subterm.copy().into()));
+                    assert_eq!(MatchTermInner::Term(subterm.copy().into()), match_term.get_position(&position));
+                }
+            }
+
+            //assert_eq!(&match_term.to_term(&mut tp), t, "The to_term function should return the original");
+        }
+
+    }
+}

--- a/libraries/sabre/src/utilities/mod.rs
+++ b/libraries/sabre/src/utilities/mod.rs
@@ -1,11 +1,13 @@
 mod configuration_stack;
 mod innermost_stack;
+mod match_term;
 mod position;
 mod semi_compressed_tree;
 mod substitution;
 
-pub(crate) use innermost_stack::*;
-pub(crate) use configuration_stack::*;
+pub use match_term::*;
 pub use position::*;
 pub use semi_compressed_tree::*;
 pub use substitution::*;
+pub(crate) use configuration_stack::*;
+pub(crate) use innermost_stack::*;

--- a/libraries/sabre/src/utilities/substitution.rs
+++ b/libraries/sabre/src/utilities/substitution.rs
@@ -1,5 +1,5 @@
 use ahash::AHashSet;
-use mcrl2::{aterm::{ATerm, TermBuilder, Yield, TermPool, Protected, ATermRef}, data::{DataExpression, DataVariable, DataFunctionSymbol}};
+use mcrl2::{aterm::{ATerm, ATermRef, ATermReturn, Protected, TermBuilder, TermPool, Yield}, data::{DataExpression, DataFunctionSymbol, DataVariable}};
 
 pub type SubstitutionBuilder = Protected<Vec<ATermRef<'static>>>;
 
@@ -75,9 +75,11 @@ pub fn to_untyped_data_expression(tp: &mut TermPool, t: &ATerm, variables: &AHas
 
         if variables.contains(t.get_head_symbol().name()) {
             // Convert a constant variable, for example 'x', into an untyped variable.
-            Ok(Yield::Term(DataVariable::new(tp, t.get_head_symbol().name()).into()))
+            let t: &ATermRef<'_> = &DataVariable::new(tp, t.get_head_symbol().name());
+            Ok(Yield::Term(t.copy().into()))
         } else if t.get_head_symbol().arity() == 0 {
-            Ok(Yield::Term(DataFunctionSymbol::new(tp, t.get_head_symbol().name()).into()))
+            let t: &ATermRef<'_> = &DataFunctionSymbol::new(tp, t.get_head_symbol().name());
+            Ok(Yield::Term(t.copy().into()))
         } else {
             // This is a function symbol applied to a number of arguments (higher order terms not allowed)
             let head = DataFunctionSymbol::new(tp, t.get_head_symbol().name());


### PR DESCRIPTION
Several ideas from jitty that could benefit the rewrite performance, implemented so far:
 - [x] Implemented a MatchTerm that can be used to avoid constructing the term to be matched.
 - [ ] Use a MatchTerm construction for the semi compressed tree, avoiding construction for rewriting conditions.