### PR TITLE
Use a combined backwards marking and topological sort to avoid naive sorting

### DIFF
--- a/libraries/lts/src/reduction/block_partition.rs
+++ b/libraries/lts/src/reduction/block_partition.rs
@@ -112,6 +112,7 @@ impl BlockPartition {
             it -= 1;
         }
 
+        self.blocks[block_index] = block;
         self.assert_consistent();
     }
 

--- a/libraries/lts/src/reduction/signature_refinement.rs
+++ b/libraries/lts/src/reduction/signature_refinement.rs
@@ -208,7 +208,7 @@ where
         );
 
         for new_block_index in
-            partition.partition_marked_with(block_index, &mut split_builder, |state_index, partition| {
+            partition.partition_marked_with(block_index, &mut split_builder, &incoming, &lts, |state_index, partition| {
                 // Compute the signature of a single state
                 let index = if let Some(key) = signature(state_index, partition, &state_to_key, &key_to_signature, &mut builder) {
                     // The signature refers to an existing block.

--- a/libraries/lts/src/reduction/signature_refinement.rs
+++ b/libraries/lts/src/reduction/signature_refinement.rs
@@ -190,7 +190,6 @@ where
 
     // Used to keep track of dirty blocks.
     let mut worklist = vec![0];
-    let mut stack = Vec::new();
 
     while let Some(block_index) = worklist.pop() {
         // Clear the current partition to start the next blocks.
@@ -245,7 +244,14 @@ where
                             if !lts.is_hidden_label(label_index)
                                 || partition.block_number(incoming_state) != partition.block_number(state_index)
                             {
-                                mark_inert_tau(&mut partition, &mut worklist, &mut stack, &incoming, incoming_state);
+                                let other_block = partition.block_number(incoming_state);
+
+                                if !partition.block(other_block).has_marked() {
+                                    // If block was not already marked then add it to the worklist.
+                                    worklist.push(other_block);
+                                }
+    
+                                partition.mark_element(incoming_state);
                             }
                         } else {
                             // In this case mark all incoming states.


### PR DESCRIPTION
This is just a pull request to run the tests, and prepared for rebasing.

It might be useful to have a outgoing_hidden_transitions by grouping the hidden and non-hidden transitions, possibly even not storing a label for the hidden transitions.